### PR TITLE
スプレッドシートIDの設定が必要なことをREADMEに追記する。

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ This is a checkpoint service using NFC tags and Google Apps Script. The service 
 6. Modify property of the `.clasp.json` to ` "rootDir":"./gas"`
 7. Push the local code to the Apps Script project with manifest overwriting: `clasp:push`
 8. Open the Apps Script project in the browser: `clasp open`
-9. Deploy the project as a web app and get the deployment ID
-10. Open the `public/index.html` file and input the deployment ID in the field `API Key`
-11. Open the list of records page or card reader page
+9. Replace REPLACE_SPREAD_SHEET_ID in code.gs with the spreadsheet ID of the "Nfc-checkpoint" spreadsheet.
+10. Deploy the project as a web app and get the deployment ID
+11. Open the `public/index.html` file and input the deployment ID in the field `API Key`
+12. Open the list of records page or card reader page
 
 ## Development
 


### PR DESCRIPTION
スプレッドシートIDの設定が必要なことをREADMEに追記する。

この設定をおこなってからデプロイしないと、カードの読み取り時、エラーがでます。