### PR TITLE
チェックインした後のレスポンスを改善。

### DIFF
--- a/public/input.html
+++ b/public/input.html
@@ -259,6 +259,11 @@
                 clearButton.classList.remove('button-inactive');
                 readID = idm;
                 document.getElementById('idm').innerHTML = `IDm: ${idm}`;
+
+                recorder.recordList.push([(new Date()).toISOString(), idm]);
+                recorder.updateCheckList();
+                updateCheckListTable(false);
+
                 await recorder.recordID(idm);
                 const name = await recorder.getNameForId(readID);
                 document.getElementById('recordedData').innerHTML
@@ -273,9 +278,6 @@
                 statusField.classList.remove('is-warning');
                 statusField.classList.add('is-success');
                 document.getElementById('changeNameButton').classList.remove('button-inactive');
-                setTimeout(() => {
-                    updateRecordTable();
-                }, 1000);
             } catch (error) {
                 document.getElementById('status').innerHTML = error;
                 console.error(error);
@@ -350,8 +352,12 @@
          * Update the record table with the given data.
          * @param {Array} data - The data to update the record table with.
          */
-        async function updateCheckListTable() {
-            await recorder.updateRecordList();
+        async function updateCheckListTable(shouldWaitForRecordListUpdate = true) {
+            if (shouldWaitForRecordListUpdate) {
+                await recorder.updateRecordList();
+            } else {
+                recorder.updateRecordList();
+            }
             const checkList = recorder.checkList;
             document.getElementById('last-record').innerHTML = `最終記録: ${recorder.lastRecordTime ? formatDate(recorder.lastRecordTime) : '未記録'}`;
             const nameList = await recorder.getNameList();

--- a/public/input.html
+++ b/public/input.html
@@ -348,40 +348,53 @@
             document.getElementById('recordedData').innerHTML = '';
         });
 
+        let isUpdatingCheckList = false; // ロックフラグを追加
+
         /**
          * Update the record table with the given data.
          * @param {Array} data - The data to update the record table with.
          */
         async function updateCheckListTable(shouldWaitForRecordListUpdate = true) {
-            if (shouldWaitForRecordListUpdate) {
-                await recorder.updateRecordList();
-            } else {
-                recorder.updateRecordList();
+            // 既に実行中の場合は終了
+            if (isUpdatingCheckList) {
+                return;
             }
-            const checkList = recorder.checkList;
-            document.getElementById('last-record').innerHTML = `最終記録: ${recorder.lastRecordTime ? formatDate(recorder.lastRecordTime) : '未記録'}`;
-            const nameList = await recorder.getNameList();
-            var table = document.getElementById('checkListTable');
-            // Clear the table first
-            while (table.rows.length > 1) {
-                table.deleteRow(1);
-            }
-            // Then add new data
-            for (let id in checkList) {
-                let row = table.insertRow(-1);
-                let cell;
-                cell = row.insertCell(-1);
-                const name = nameList[id];
-                cell.innerHTML = name ? name : `ID: ${id}`;
-                cell = row.insertCell(-1);
-                cell.innerHTML = formatDate(checkList[id].in, false);
-                cell = row.insertCell(-1);
-                if (checkList[id].out) {
-                    cell.innerHTML = formatDate(checkList[id].out, false);
+
+            try {
+                isUpdatingCheckList = true; // ロックを取得
+
+                if (shouldWaitForRecordListUpdate) {
+                    await recorder.updateRecordList();
                 } else {
-                    cell.innerHTML = '未退室';
-                    cell.classList.add('is-danger');
+                    recorder.updateRecordList();
                 }
+                const checkList = recorder.checkList;
+                document.getElementById('last-record').innerHTML = `最終記録: ${recorder.lastRecordTime ? formatDate(recorder.lastRecordTime) : '未記録'}`;
+                const nameList = await recorder.getNameList();
+                var table = document.getElementById('checkListTable');
+                // Clear the table first
+                while (table.rows.length > 1) {
+                    table.deleteRow(1);
+                }
+                // Then add new data
+                for (let id in checkList) {
+                    let row = table.insertRow(-1);
+                    let cell;
+                    cell = row.insertCell(-1);
+                    const name = nameList[id];
+                    cell.innerHTML = name ? name : `ID: ${id}`;
+                    cell = row.insertCell(-1);
+                    cell.innerHTML = formatDate(checkList[id].in, false);
+                    cell = row.insertCell(-1);
+                    if (checkList[id].out) {
+                        cell.innerHTML = formatDate(checkList[id].out, false);
+                    } else {
+                        cell.innerHTML = '未退室';
+                        cell.classList.add('is-danger');
+                    }
+                }
+            } finally {
+                isUpdatingCheckList = false; // 必ずロックを解放
             }
         }
         // Update automatically


### PR DESCRIPTION
チェックインした後に、入退室の表が即座に更新されるようにしました。

readCardの処理の中で、spreadsheet にデータを送る前に、recorder.recordList を先に更新してしまって、

- recorder.updateCheckList
- updateCheckListTable

を呼んで入退室の表を更新しています。

updateCheckListTable 内で recorder.updateRecordList を呼んでいるのですが、readCard 処理から呼ばれたときには非同期で呼ぶようにして、そこで待ちが発生しないようにしています。

updateCheckListTable は10秒に一度、定期的にも呼ばれているので、同時に起こるのを防ぐためにロックをかけています。

https://gyazo.com/d258d5784b38e4e8a5f58cb5f1488a98